### PR TITLE
feat: Implement real-time collaborative code editor

### DIFF
--- a/convex/interviews.ts
+++ b/convex/interviews.ts
@@ -50,9 +50,32 @@ export const createInterview = mutation({
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) throw new Error("Unauthorized");
 
+    // 1. Create a new document
+    const documentId = await ctx.db.insert("documents", {
+      content: "", // Initial empty content
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    if (!documentId) {
+      throw new Error("Failed to create document for the interview.");
+    }
+
+    // 2. Insert the interview with the new documentId
     return await ctx.db.insert("interviews", {
       ...args,
+      documentId: documentId, // Add the documentId here
     });
+  },
+});
+
+export const getInterviewById = query({
+  args: { id: v.id("interviews") },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Unauthorized"); // Or handle as per app's auth policy
+
+    return await ctx.db.get(args.id);
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -19,6 +19,7 @@ export default defineSchema({
     streamCallId: v.string(),
     candidateId: v.string(),
     interviewerIds: v.array(v.string()),
+  documentId: v.optional(v.id("documents")), // <-- New field
   })
     .index("by_candidate_id", ["candidateId"])
     .index("by_stream_call_id", ["streamCallId"]),

--- a/src/app/(root)/meeting/[id]/page.tsx
+++ b/src/app/(root)/meeting/[id]/page.tsx
@@ -8,20 +8,40 @@ import { useUser } from "@clerk/nextjs";
 import { StreamCall, StreamTheme } from "@stream-io/video-react-sdk";
 import { useParams } from "next/navigation";
 import { useState } from "react";
+import { useQuery } from "convex/react";
+import { api } from "../../../../../convex/_generated/api"; // Adjusted path
+// Id import might not be directly needed here if only passing interview._id of type string
+// but good for type safety if we were to use the Id type explicitly for interviewId prop
+// import { Id } from "../../../../../convex/_generated/dataModel";
 
 function MeetingPage() {
-  const { id } = useParams();
+  const { id: streamCallId } = useParams(); // Renamed for clarity
   const { isLoaded } = useUser();
-  const { call, isCallLoading } = useGetCallById(id);
+  const { call, isCallLoading } = useGetCallById(streamCallId);
+
+  const interview = useQuery(
+    api.interviews.getInterviewByStreamCallId,
+    streamCallId ? { streamCallId: streamCallId as string } : "skip"
+  );
 
   const [isSetupComplete, setIsSetupComplete] = useState(false);
 
-  if (!isLoaded || isCallLoading) return <LoaderUI />;
+  if (!isLoaded || isCallLoading || (streamCallId && interview === undefined)) {
+    return <LoaderUI />;
+  }
 
   if (!call) {
     return (
       <div className="h-screen flex items-center justify-center">
         <p className="text-2xl font-semibold">Meeting not found</p>
+      </div>
+    );
+  }
+
+  if (streamCallId && !interview) { // interview is null if not found, undefined if loading (handled above)
+    return (
+      <div className="h-screen flex items-center justify-center">
+        <p className="text-2xl font-semibold">Interview details not found for this meeting.</p>
       </div>
     );
   }
@@ -32,7 +52,8 @@ function MeetingPage() {
         {!isSetupComplete ? (
           <MeetingSetup onSetupComplete={() => setIsSetupComplete(true)} />
         ) : (
-          <MeetingRoom />
+          // Ensure interview and interview._id are available before rendering MeetingRoom
+          interview && <MeetingRoom interviewId={interview._id} />
         )}
       </StreamTheme>
     </StreamCall>

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -1,27 +1,83 @@
 import { CODING_QUESTIONS, LANGUAGES } from "@/constants";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "./ui/resizable";
 import { ScrollArea, ScrollBar } from "./ui/scroll-area";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import { AlertCircleIcon, BookIcon, LightbulbIcon } from "lucide-react";
 import Editor from "@monaco-editor/react";
+import { Id } from "../../convex/_generated/dataModel";
+import { useQuery, useMutation } from "convex/react";
+import { api } from "../../convex/_generated/api";
 
-function CodeEditor() {
+interface CodeEditorProps {
+  interviewId: Id<"interviews">;
+}
+
+function CodeEditor(props: CodeEditorProps) {
+  const { interviewId } = props;
+
   const [selectedQuestion, setSelectedQuestion] = useState(CODING_QUESTIONS[0]);
   const [language, setLanguage] = useState<"javascript" | "python" | "java">(LANGUAGES[0].id);
-  const [code, setCode] = useState(selectedQuestion.starterCode[language]);
+  const [editorContent, setEditorContent] = useState<string>("");
+
+  const interviewData = useQuery(api.interviews.getInterviewById, { id: interviewId });
+  const documentId = interviewData?.documentId;
+
+  // Corrected skip logic: only run if documentId is a valid string
+  const documentFromDB = useQuery(
+    api.documents.get,
+    documentId ? { id: documentId } : "skip"
+  );
+  const updateDocument = useMutation(api.documents.update);
+
+  useEffect(() => {
+    if (documentFromDB && documentFromDB.content !== editorContent) {
+      if (documentId) {
+        console.log("Document updated remotely, refreshing editor for document:", documentId);
+      }
+      setEditorContent(documentFromDB.content);
+    } else if (documentFromDB && documentFromDB.content === "" && editorContent === "" && selectedQuestion && language && documentId) {
+      console.log("Initializing editor with starter code for document:", documentId);
+      const starter = selectedQuestion.starterCode[language];
+      setEditorContent(starter);
+      updateDocument({ id: documentId, content: starter })
+        .catch(err => console.error("Failed to initialize document " + documentId + " with starter code:", err));
+    }
+  }, [documentFromDB, selectedQuestion, language, documentId, updateDocument, editorContent]); // editorContent is needed here to prevent re-initializing if user starts typing before doc loads
+
+  const handleEditorChange = (value: string | undefined) => {
+    const newContent = value || "";
+    setEditorContent(newContent);
+    if (documentId && documentFromDB && newContent !== documentFromDB.content) {
+      console.log("Sending update to document:", documentId);
+      updateDocument({ id: documentId, content: newContent })
+        .catch(err => console.error("Failed to save changes for document " + documentId + ":", err));
+    }
+  };
 
   const handleQuestionChange = (questionId: string) => {
     const question = CODING_QUESTIONS.find((q) => q.id === questionId)!;
     setSelectedQuestion(question);
-    setCode(question.starterCode[language]);
+    // Starter code initialization is handled by the useEffect
   };
 
   const handleLanguageChange = (newLanguage: "javascript" | "python" | "java") => {
     setLanguage(newLanguage);
-    setCode(selectedQuestion.starterCode[newLanguage]);
+    // Starter code initialization is handled by the useEffect
   };
+
+  // Refined Loading/Error States
+  if (interviewData === undefined) return <p className="p-4">Loading interview data...</p>;
+  if (interviewData === null) return <p className="p-4">Interview not found.</p>;
+
+  // At this point, interviewData is valid.
+  if (!documentId) return <p className="p-4">Document ID missing for this interview. This may be an old interview.</p>;
+
+  // Now handle document loading
+  if (documentFromDB === undefined) return <p className="p-4">Loading document...</p>;
+  if (documentFromDB === null) return <p className="p-4">Collaborative document not found or access denied for ID: {documentId}</p>;
+  // If we reach here, documentFromDB is the actual document object.
 
   return (
     <ResizablePanelGroup direction="vertical" className="min-h-[calc-100vh-4rem-1px]">
@@ -165,11 +221,11 @@ function CodeEditor() {
         <div className="h-full relative">
           <Editor
             height={"100%"}
-            defaultLanguage={language}
+            defaultLanguage={language} // Ensure this is dynamically updated if language changes
             language={language}
             theme="vs-dark"
-            value={code}
-            onChange={(value) => setCode(value || "")}
+            value={editorContent}
+            onChange={handleEditorChange}
             options={{
               minimap: { enabled: false },
               fontSize: 18,

--- a/src/components/MeetingRoom.tsx
+++ b/src/components/MeetingRoom.tsx
@@ -19,8 +19,13 @@ import {
 import { Button } from "./ui/button";
 import EndCallButton from "./EndCallButton";
 import CodeEditor from "./CodeEditor";
+import { Id } from "../../convex/_generated/dataModel"; // Adjusted path
 
-function MeetingRoom() {
+interface MeetingRoomProps {
+  interviewId: Id<"interviews">;
+}
+
+function MeetingRoom({ interviewId }: MeetingRoomProps) {
   const router = useRouter();
   const [layout, setLayout] = useState<"grid" | "speaker">("speaker");
   const [showParticipants, setShowParticipants] = useState(false);
@@ -95,7 +100,7 @@ function MeetingRoom() {
         <ResizableHandle withHandle />
 
         <ResizablePanel defaultSize={65} minSize={25}>
-          <CodeEditor />
+          <CodeEditor interviewId={interviewId} />
         </ResizablePanel>
       </ResizablePanelGroup>
     </div>


### PR DESCRIPTION
This commit introduces a real-time collaborative code editor for interview sessions.

Key changes include:

1.  **Schema Update:** Added an optional `documentId` field to the `interviews` table in `convex/schema.ts` to link interviews with shared code documents.

2.  **Interview Logic:** Modified the `createInterview` mutation in `convex/interviews.ts` to automatically create an associated empty document in the `documents` table and store its ID in the interview record.

3.  **Collaborative CodeEditor.tsx:**
    *   Refactored `src/components/CodeEditor.tsx` to accept an `interviewId` prop.
    *   The component now fetches the associated `documentId` from the interview data.
    *   It uses Convex queries (`api.documents.get`) to load the document content and mutations (`api.documents.update`) to save changes.
    *   Content is synchronized in real-time across all users viewing the same interview's editor, leveraging Convex's live query capabilities.
    *   Initial starter code (based on selected question and language) is populated into the document if it's empty.
    *   Enhanced error handling for data fetching and update mutations.
    *   Added client-side logging for key collaborative events and potential errors.

4.  **Integration into Meeting Page:**
    *   The `CodeEditor` is integrated into `src/components/MeetingRoom.tsx`.
    *   `src/app/(root)/meeting/[id]/page.tsx` now fetches the `interview` details using the `streamCallId` from the URL, retrieves the `interview._id`, and passes it to the `MeetingRoom` and subsequently to the `CodeEditor`.
    *   Loading and error states for fetching interview/document data are handled.

5.  **IDE Features:** The editor continues to support syntax highlighting (per your language selection) and basic IDE functionalities provided by the Monaco Editor.

This feature allows interviewers and candidates to code together simultaneously during a live interview session, with changes reflected live for all participants.